### PR TITLE
Forbid Dispatch From Within Reducers

### DIFF
--- a/ReduxKit/CreateStore.swift
+++ b/ReduxKit/CreateStore.swift
@@ -41,10 +41,21 @@ public func createStreamStore<State>(
         state: State?)
     -> Store<State> {
 
+    var isDispatching = false
     let stream = streamFactory(state ?? reducer(state, DefaultAction()))
 
     func dispatch(action: Action) -> Action {
-        stream.dispatch(reducer(stream.getState(), action))
+        if isDispatching {
+            // Use Obj-C exception since throwing of exceptions can be verified through tests
+            NSException.raise("ReduxKit:IllegalDispatchFromReducer", format: "Reducers may not " +
+                "dispatch actions.", arguments: getVaList(["nil"]))
+        }
+
+        isDispatching = true
+        let newState = reducer(stream.getState(), action)
+        isDispatching = false
+
+        stream.dispatch(newState)
         return action
     }
 

--- a/ReduxKitTests/CreateStoreSpec.swift
+++ b/ReduxKitTests/CreateStoreSpec.swift
@@ -53,6 +53,39 @@ class CreateStoreSpec: QuickSpec {
                 expect(state.counter).to(equal(defaultState.counter + iterations))
             }
 
+            it("should forbid dispatching actions from within reducers") {
+                /*
+                    Reducers should be free of side effects, therefore dispatching actions from
+                    within reducers is illegal.
+                */
+
+                // Arrange
+                var storeWithDispatchingReducer: Store<AppState>!
+
+                func dispatchingReducer(state: AppState? = nil, action: Action) -> AppState {
+                    // Set up the initial state when reducing `DefaultAction`
+                    if action is DefaultAction {
+                        return AppState()
+                    } else if action is IncrementAction {
+                        // Attempt to dispatch a new action when reducing `IncrementAction`
+
+                        // Act: Dispatch from within Reducer & Assert
+                        expect(
+                            storeWithDispatchingReducer.dispatch(
+                                PushAction(payload: PushAction.Payload(text: "Test")))
+                            )
+                        .to(raiseException(named:"ReduxKit:IllegalDispatchFromReducer"))
+                    }
+
+                    return AppState()
+                }
+
+                storeWithDispatchingReducer = createStore(dispatchingReducer, state: nil)
+
+                // Act: Dispatch Initial Action
+                storeWithDispatchingReducer.dispatch(IncrementAction())
+            }
+
             it("should fetch the latest state") {
                 // Arrange
                 var state: AppState!


### PR DESCRIPTION
Just as Redux we should forbid dispatching actions from within reducers, since reducers should be free of side-effects.

[I've just implemented this for Swift Flow](https://github.com/Swift-Flow/Swift-Flow/pull/13) and thought it would make sense to bring this into ReduxKit as well. I'm not sure if implementation & specs fit your style, so I'm looking forward to feedback!
