### PR TITLE
Simplified actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,35 +84,35 @@ A more advanced Swift example of the original [gist](https://github.com/rackt/re
 import ReduxKit
 
 /**
-  * This is a simple standard action. The only requirement is that an action complies to
-  * the Action protocol. The SimpleStandardAction contains a strongly typed rawPayload
-  * property. The protocol automatically assigns the rawPayload to the Actions payload
-  * property. This removes the necessity of type casting whenever working with actions in
-  * a reducer.
-  *
-  * There's also the StandardAction protocol, that requires the struct to have an
-  * initializer. This is required if the bindActionCreators helper is to be used.
-  */
-struct IncrementAction: SimpleStandardAction {
-    let meta: Any? = nil
-    let error: Bool = false
-    let rawPayload: Int = 1
+ This is an extremely simple and flexible action. The only requirement for actions is that they
+ conform to the Action protocol.
+
+ The Action protocol can be inherited from for app specific Action requirements. For a good example
+ of this, see FluxStandardAction and the implementing types in the source.
+
+ Action can be implemented as an enum, struct or class.
+ */
+struct IncrementAction: Action {
+    let payload: Int
+    init(payload: Int = 1) {
+        self.payload = payload
+    }
 }
 
-struct DecrementAction: SimpleStandardAction {
-    let meta: Any? = nil
-    let error: Bool = false
-    let rawPayload: Int = 1
+struct DecrementAction: Action {
+    let payload: Int
+    init(payload: Int = 1) {
+        self.payload = payload
+    }
 }
 
 /**
-  * This is a simple reducer. It is a pure function that follows the syntax
-  * (state, action) -> state.
-  * It describes how an action transforms the previous state into the next state.
-  *
-  * Instead of using the actions.type property - as is done in the regular Redux framework
-  * we use the power of Swifts static typing to deduce the action.
-  */
+ This is a simple reducer. It is a pure function that follows the syntax (State, Action) -> State.
+ It describes how an action transforms the previous state into the next state.
+
+ Instead of using the Action.type property - as is done in the regular Redux framework we use the
+ power of Swifts static typing to deduce the action.
+ */
 func counterReducer(previousState: Int?, action: Action) -> Int {
     // Declare the reducers default value
     let defaultValue = 0
@@ -120,42 +120,41 @@ func counterReducer(previousState: Int?, action: Action) -> Int {
 
     switch action {
         case let action as IncrementAction:
-            return state + action.rawPayload
+            return state + action.payload
         case let action as DecrementAction:
-            return state - action.rawPayload
+            return state - action.payload
         default:
             return state
     }
 }
 
 /**
-  * The applications state. This should contain the state of the whole application.
-  * When building larger applications, you can optionally assign complex structs to
-  * properties on the AppState and handle them in the part of the application that
-  * uses them.
-  */
+ The applications state. This should contain the state of the whole application.
+ When building larger applications, you can optionally assign complex structs to properties on the
+ AppState and handle them in the part of the application that uses them.
+ */
 struct AppState {
-  var count: Int!
+    var count: Int!
 }
 
 /**
-  * Create the applications reducer. While we could create a combineReducer function
-  * we've currently chosen to allow reducers to be statically typed and accept
-  * static states - instead of Any - which currently forces us to define the
-  * application reducer as such. This could possibly be simplified with reflection.
-  */
+ Create the applications reducer. While we could create a combineReducer function we've currently
+ chosen to allow reducers to be statically typed and accept static states - instead of Any - which
+ currently forces us to define the application reducer as such. This could possibly be simplified
+ with reflection.
+ */
 let applicationReducer = {(state: AppState? = nil, action: Action) -> AppState in
 
-  return AppState(
-    count: counterReducer(state?.count, action: action),
+    return AppState(
+        count: counterReducer(state?.count, action: action),
     )
 }
 
 // Create application store. The second parameter is an optional default state.
 let store = createStore(applicationReducer, nil)
 
-let disposable = store.subscribe{ state in
-  print(state)
+let disposable = store.subscribe { state in
+    print(state)
 }
 
 

--- a/ReduxKit.xcodeproj/project.pbxproj
+++ b/ReduxKit.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		73971CBE1C243F41005AC995 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843601C243C6300644EEC /* Nimble.framework */; };
 		73971CBF1C243F44005AC995 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843611C243C6300644EEC /* Quick.framework */; };
 		73971CC21C24409D005AC995 /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73D383E91C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
+		73D383EA1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
+		73D383EB1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
+		73D383EC1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
 		73D6282A1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
 		73D6282B1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
 		73D6282C1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
@@ -111,6 +115,7 @@
 		7389B88B1C24436200D58617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		7389B88C1C24436200D58617 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareApiSpec.swift; sourceTree = "<group>"; };
+		73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluxStandardAction.swift; sourceTree = "<group>"; };
 		73D628291C4094330098579E /* StoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSpec.swift; sourceTree = "<group>"; };
 		73D842EA1C24369900644EEC /* ReduxKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReduxKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73D842EC1C24369900644EEC /* ReduxKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReduxKit.h; sourceTree = "<group>"; };
@@ -220,6 +225,7 @@
 				73D843311C243A8D00644EEC /* Compose.swift */,
 				73D843321C243A8D00644EEC /* CreateStore.swift */,
 				73D843331C243A8D00644EEC /* Disposable.swift */,
+				73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */,
 				73061FAA1C2BB644005FA55E /* MiddlewareApi.swift */,
 				73D843351C243A8D00644EEC /* Store.swift */,
 			);
@@ -679,6 +685,7 @@
 				738EEA301C302D7000797452 /* Store.swift in Sources */,
 				738EEA291C302D7000797452 /* Action.swift in Sources */,
 				738EEA2A1C302D7000797452 /* ApplyMiddleware.swift in Sources */,
+				73D383EB1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
 				738EEA2C1C302D7000797452 /* Compose.swift in Sources */,
 				738EEA2E1C302D7000797452 /* Disposable.swift in Sources */,
 				738EEA2D1C302D7000797452 /* CreateStore.swift in Sources */,
@@ -708,6 +715,7 @@
 				73D8435C1C243A8D00644EEC /* Store.swift in Sources */,
 				73D8433E1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
 				73D843431C243A8D00644EEC /* BindActionCreators.swift in Sources */,
+				73D383EA1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
 				73D843481C243A8D00644EEC /* Compose.swift in Sources */,
 				73061FAC1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843391C243A8D00644EEC /* Action.swift in Sources */,
@@ -723,6 +731,7 @@
 				73D8435B1C243A8D00644EEC /* Store.swift in Sources */,
 				73D8433D1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
 				73D843421C243A8D00644EEC /* BindActionCreators.swift in Sources */,
+				73D383EC1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
 				73D843471C243A8D00644EEC /* Compose.swift in Sources */,
 				73061FAE1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843381C243A8D00644EEC /* Action.swift in Sources */,
@@ -752,6 +761,7 @@
 				73D843591C243A8D00644EEC /* Store.swift in Sources */,
 				73D843401C243A8D00644EEC /* BindActionCreators.swift in Sources */,
 				73D8434F1C243A8D00644EEC /* Disposable.swift in Sources */,
+				73D383E91C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
 				73D8433B1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
 				73061FAB1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843451C243A8D00644EEC /* Compose.swift in Sources */,

--- a/ReduxKit.xcodeproj/project.pbxproj
+++ b/ReduxKit.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		73061FAD1C2BB644005FA55E /* MiddlewareApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73061FAA1C2BB644005FA55E /* MiddlewareApi.swift */; };
 		73061FAE1C2BB644005FA55E /* MiddlewareApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73061FAA1C2BB644005FA55E /* MiddlewareApi.swift */; };
 		73552BD81C298D87003B7389 /* ReduxKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73552BCE1C298D87003B7389 /* ReduxKit.framework */; };
-		73552BE61C2990A5003B7389 /* ActionTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* ActionTypeSpec.swift */; };
+		73552BE61C2990A5003B7389 /* FluxStandardActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* FluxStandardActionSpec.swift */; };
 		73552BE71C2990A5003B7389 /* ApplyMiddlewaresSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */; };
 		73552BE81C2990A5003B7389 /* BindActionCreatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431E1C24399200644EEC /* BindActionCreatorsSpec.swift */; };
 		73552BE91C2990A5003B7389 /* CreateStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431F1C24399200644EEC /* CreateStoreSpec.swift */; };
@@ -37,11 +37,11 @@
 		73D383EA1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
 		73D383EB1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
 		73D383EC1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
-		73D6282A1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
-		73D6282B1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
-		73D6282C1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
+		73D6282A1C4094330098579E /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* ActionSpec.swift */; };
+		73D6282B1C4094330098579E /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* ActionSpec.swift */; };
+		73D6282C1C4094330098579E /* ActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* ActionSpec.swift */; };
 		73D842ED1C24369900644EEC /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		73D843211C24399200644EEC /* ActionTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* ActionTypeSpec.swift */; };
+		73D843211C24399200644EEC /* FluxStandardActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* FluxStandardActionSpec.swift */; };
 		73D843231C24399200644EEC /* ApplyMiddlewaresSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */; };
 		73D843251C24399200644EEC /* BindActionCreatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431E1C24399200644EEC /* BindActionCreatorsSpec.swift */; };
 		73D843271C24399200644EEC /* CreateStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431F1C24399200644EEC /* CreateStoreSpec.swift */; };
@@ -69,7 +69,7 @@
 		73D8435C1C243A8D00644EEC /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D843351C243A8D00644EEC /* Store.swift */; };
 		73D8435E1C243B7200644EEC /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		73D8436D1C243C8800644EEC /* ReduxKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D842EA1C24369900644EEC /* ReduxKit.framework */; };
-		73D843731C243CCE00644EEC /* ActionTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* ActionTypeSpec.swift */; };
+		73D843731C243CCE00644EEC /* FluxStandardActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* FluxStandardActionSpec.swift */; };
 		73D843741C243CCE00644EEC /* ApplyMiddlewaresSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */; };
 		73D843751C243CCE00644EEC /* BindActionCreatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431E1C24399200644EEC /* BindActionCreatorsSpec.swift */; };
 		73D843761C243CCE00644EEC /* CreateStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431F1C24399200644EEC /* CreateStoreSpec.swift */; };
@@ -116,13 +116,13 @@
 		7389B88C1C24436200D58617 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareApiSpec.swift; sourceTree = "<group>"; };
 		73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluxStandardAction.swift; sourceTree = "<group>"; };
-		73D628291C4094330098579E /* StoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSpec.swift; sourceTree = "<group>"; };
+		73D628291C4094330098579E /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSpec.swift; sourceTree = "<group>"; };
 		73D842EA1C24369900644EEC /* ReduxKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReduxKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73D842EC1C24369900644EEC /* ReduxKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReduxKit.h; sourceTree = "<group>"; };
 		73D842EE1C24369900644EEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		73D842FA1C24369900644EEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		73D843131C24377F00644EEC /* ReduxKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReduxKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		73D8431C1C24399200644EEC /* ActionTypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionTypeSpec.swift; sourceTree = "<group>"; };
+		73D8431C1C24399200644EEC /* FluxStandardActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluxStandardActionSpec.swift; sourceTree = "<group>"; };
 		73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplyMiddlewaresSpec.swift; sourceTree = "<group>"; };
 		73D8431E1C24399200644EEC /* BindActionCreatorsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindActionCreatorsSpec.swift; sourceTree = "<group>"; };
 		73D8431F1C24399200644EEC /* CreateStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateStoreSpec.swift; sourceTree = "<group>"; };
@@ -236,13 +236,13 @@
 			isa = PBXGroup;
 			children = (
 				73D842FA1C24369900644EEC /* Info.plist */,
-				73D8431C1C24399200644EEC /* ActionTypeSpec.swift */,
+				73D628291C4094330098579E /* ActionSpec.swift */,
 				73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */,
 				73D8431E1C24399200644EEC /* BindActionCreatorsSpec.swift */,
 				73D8431F1C24399200644EEC /* CreateStoreSpec.swift */,
+				73D8431C1C24399200644EEC /* FluxStandardActionSpec.swift */,
 				738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */,
 				73D843201C24399200644EEC /* Mocks.swift */,
-				73D628291C4094330098579E /* StoreSpec.swift */,
 				73D8431B1C24392900644EEC /* Dependencies iOS */,
 				73D8435F1C243C3000644EEC /* Dependencies Mac */,
 				7389B88A1C24433F00D58617 /* Dependencies tvOS */,
@@ -697,9 +697,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				73552BE91C2990A5003B7389 /* CreateStoreSpec.swift in Sources */,
-				73D6282C1C4094330098579E /* StoreSpec.swift in Sources */,
+				73D6282C1C4094330098579E /* ActionSpec.swift in Sources */,
 				738EEA281C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
-				73552BE61C2990A5003B7389 /* ActionTypeSpec.swift in Sources */,
+				73552BE61C2990A5003B7389 /* FluxStandardActionSpec.swift in Sources */,
 				73552BE71C2990A5003B7389 /* ApplyMiddlewaresSpec.swift in Sources */,
 				73552BE81C2990A5003B7389 /* BindActionCreatorsSpec.swift in Sources */,
 				73552BEA1C2990A5003B7389 /* Mocks.swift in Sources */,
@@ -743,11 +743,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				73D843751C243CCE00644EEC /* BindActionCreatorsSpec.swift in Sources */,
-				73D6282B1C4094330098579E /* StoreSpec.swift in Sources */,
+				73D6282B1C4094330098579E /* ActionSpec.swift in Sources */,
 				738EEA271C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
 				73D843741C243CCE00644EEC /* ApplyMiddlewaresSpec.swift in Sources */,
 				73D843761C243CCE00644EEC /* CreateStoreSpec.swift in Sources */,
-				73D843731C243CCE00644EEC /* ActionTypeSpec.swift in Sources */,
+				73D843731C243CCE00644EEC /* FluxStandardActionSpec.swift in Sources */,
 				73D843771C243CCE00644EEC /* Mocks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -773,12 +773,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				73D843271C24399200644EEC /* CreateStoreSpec.swift in Sources */,
-				73D6282A1C4094330098579E /* StoreSpec.swift in Sources */,
+				73D6282A1C4094330098579E /* ActionSpec.swift in Sources */,
 				738EEA261C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
 				73D843231C24399200644EEC /* ApplyMiddlewaresSpec.swift in Sources */,
 				73D843291C24399200644EEC /* Mocks.swift in Sources */,
 				73D843251C24399200644EEC /* BindActionCreatorsSpec.swift in Sources */,
-				73D843211C24399200644EEC /* ActionTypeSpec.swift in Sources */,
+				73D843211C24399200644EEC /* FluxStandardActionSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReduxKit.xcodeproj/project.pbxproj
+++ b/ReduxKit.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		73971CBE1C243F41005AC995 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843601C243C6300644EEC /* Nimble.framework */; };
 		73971CBF1C243F44005AC995 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843611C243C6300644EEC /* Quick.framework */; };
 		73971CC21C24409D005AC995 /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73D6282A1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
+		73D6282B1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
+		73D6282C1C4094330098579E /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D628291C4094330098579E /* StoreSpec.swift */; };
 		73D842ED1C24369900644EEC /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		73D843211C24399200644EEC /* ActionTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431C1C24399200644EEC /* ActionTypeSpec.swift */; };
 		73D843231C24399200644EEC /* ApplyMiddlewaresSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D8431D1C24399200644EEC /* ApplyMiddlewaresSpec.swift */; };
@@ -108,6 +111,7 @@
 		7389B88B1C24436200D58617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		7389B88C1C24436200D58617 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareApiSpec.swift; sourceTree = "<group>"; };
+		73D628291C4094330098579E /* StoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSpec.swift; sourceTree = "<group>"; };
 		73D842EA1C24369900644EEC /* ReduxKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReduxKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73D842EC1C24369900644EEC /* ReduxKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReduxKit.h; sourceTree = "<group>"; };
 		73D842EE1C24369900644EEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -232,6 +236,7 @@
 				73D8431F1C24399200644EEC /* CreateStoreSpec.swift */,
 				738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */,
 				73D843201C24399200644EEC /* Mocks.swift */,
+				73D628291C4094330098579E /* StoreSpec.swift */,
 				73D8431B1C24392900644EEC /* Dependencies iOS */,
 				73D8435F1C243C3000644EEC /* Dependencies Mac */,
 				7389B88A1C24433F00D58617 /* Dependencies tvOS */,
@@ -685,6 +690,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73552BE91C2990A5003B7389 /* CreateStoreSpec.swift in Sources */,
+				73D6282C1C4094330098579E /* StoreSpec.swift in Sources */,
 				738EEA281C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
 				73552BE61C2990A5003B7389 /* ActionTypeSpec.swift in Sources */,
 				73552BE71C2990A5003B7389 /* ApplyMiddlewaresSpec.swift in Sources */,
@@ -728,6 +734,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73D843751C243CCE00644EEC /* BindActionCreatorsSpec.swift in Sources */,
+				73D6282B1C4094330098579E /* StoreSpec.swift in Sources */,
 				738EEA271C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
 				73D843741C243CCE00644EEC /* ApplyMiddlewaresSpec.swift in Sources */,
 				73D843761C243CCE00644EEC /* CreateStoreSpec.swift in Sources */,
@@ -756,6 +763,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73D843271C24399200644EEC /* CreateStoreSpec.swift in Sources */,
+				73D6282A1C4094330098579E /* StoreSpec.swift in Sources */,
 				738EEA261C30284D00797452 /* MiddlewareApiSpec.swift in Sources */,
 				73D843231C24399200644EEC /* ApplyMiddlewaresSpec.swift in Sources */,
 				73D843291C24399200644EEC /* Mocks.swift in Sources */,

--- a/ReduxKit.xcodeproj/project.pbxproj
+++ b/ReduxKit.xcodeproj/project.pbxproj
@@ -33,6 +33,18 @@
 		73971CBE1C243F41005AC995 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843601C243C6300644EEC /* Nimble.framework */; };
 		73971CBF1C243F44005AC995 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D843611C243C6300644EEC /* Quick.framework */; };
 		73971CC21C24409D005AC995 /* ReduxKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 73D842EC1C24369900644EEC /* ReduxKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73ABF8191C40C662009179B9 /* SimpleStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */; };
+		73ABF81A1C40C662009179B9 /* SimpleStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */; };
+		73ABF81B1C40C662009179B9 /* SimpleStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */; };
+		73ABF81C1C40C662009179B9 /* SimpleStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */; };
+		73ABF81E1C40C682009179B9 /* StandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF81D1C40C682009179B9 /* StandardAction.swift */; };
+		73ABF81F1C40C682009179B9 /* StandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF81D1C40C682009179B9 /* StandardAction.swift */; };
+		73ABF8201C40C682009179B9 /* StandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF81D1C40C682009179B9 /* StandardAction.swift */; };
+		73ABF8211C40C682009179B9 /* StandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF81D1C40C682009179B9 /* StandardAction.swift */; };
+		73ABF8231C40C69A009179B9 /* DefaultAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8221C40C69A009179B9 /* DefaultAction.swift */; };
+		73ABF8241C40C69A009179B9 /* DefaultAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8221C40C69A009179B9 /* DefaultAction.swift */; };
+		73ABF8251C40C69A009179B9 /* DefaultAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8221C40C69A009179B9 /* DefaultAction.swift */; };
+		73ABF8261C40C69A009179B9 /* DefaultAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ABF8221C40C69A009179B9 /* DefaultAction.swift */; };
 		73D383E91C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
 		73D383EA1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
 		73D383EB1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */; };
@@ -115,6 +127,9 @@
 		7389B88B1C24436200D58617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		7389B88C1C24436200D58617 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		738EEA251C30284D00797452 /* MiddlewareApiSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareApiSpec.swift; sourceTree = "<group>"; };
+		73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleStandardAction.swift; sourceTree = "<group>"; };
+		73ABF81D1C40C682009179B9 /* StandardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardAction.swift; sourceTree = "<group>"; };
+		73ABF8221C40C69A009179B9 /* DefaultAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultAction.swift; sourceTree = "<group>"; };
 		73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluxStandardAction.swift; sourceTree = "<group>"; };
 		73D628291C4094330098579E /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSpec.swift; sourceTree = "<group>"; };
 		73D842EA1C24369900644EEC /* ReduxKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReduxKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -224,9 +239,12 @@
 				73D843301C243A8D00644EEC /* BindActionCreators.swift */,
 				73D843311C243A8D00644EEC /* Compose.swift */,
 				73D843321C243A8D00644EEC /* CreateStore.swift */,
+				73ABF8221C40C69A009179B9 /* DefaultAction.swift */,
 				73D843331C243A8D00644EEC /* Disposable.swift */,
 				73D383E81C4098AA00A2F063 /* FluxStandardAction.swift */,
 				73061FAA1C2BB644005FA55E /* MiddlewareApi.swift */,
+				73ABF8181C40C662009179B9 /* SimpleStandardAction.swift */,
+				73ABF81D1C40C682009179B9 /* StandardAction.swift */,
 				73D843351C243A8D00644EEC /* Store.swift */,
 			);
 			path = ReduxKit;
@@ -682,11 +700,14 @@
 			files = (
 				73061FAD1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				738EEA2B1C302D7000797452 /* BindActionCreators.swift in Sources */,
+				73ABF8201C40C682009179B9 /* StandardAction.swift in Sources */,
 				738EEA301C302D7000797452 /* Store.swift in Sources */,
 				738EEA291C302D7000797452 /* Action.swift in Sources */,
 				738EEA2A1C302D7000797452 /* ApplyMiddleware.swift in Sources */,
 				73D383EB1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
+				73ABF81B1C40C662009179B9 /* SimpleStandardAction.swift in Sources */,
 				738EEA2C1C302D7000797452 /* Compose.swift in Sources */,
+				73ABF8251C40C69A009179B9 /* DefaultAction.swift in Sources */,
 				738EEA2E1C302D7000797452 /* Disposable.swift in Sources */,
 				738EEA2D1C302D7000797452 /* CreateStore.swift in Sources */,
 			);
@@ -712,11 +733,14 @@
 			files = (
 				73D8434D1C243A8D00644EEC /* CreateStore.swift in Sources */,
 				73D843521C243A8D00644EEC /* Disposable.swift in Sources */,
+				73ABF81F1C40C682009179B9 /* StandardAction.swift in Sources */,
 				73D8435C1C243A8D00644EEC /* Store.swift in Sources */,
 				73D8433E1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
 				73D843431C243A8D00644EEC /* BindActionCreators.swift in Sources */,
 				73D383EA1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
+				73ABF81A1C40C662009179B9 /* SimpleStandardAction.swift in Sources */,
 				73D843481C243A8D00644EEC /* Compose.swift in Sources */,
+				73ABF8241C40C69A009179B9 /* DefaultAction.swift in Sources */,
 				73061FAC1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843391C243A8D00644EEC /* Action.swift in Sources */,
 			);
@@ -728,11 +752,14 @@
 			files = (
 				73D8434C1C243A8D00644EEC /* CreateStore.swift in Sources */,
 				73D843511C243A8D00644EEC /* Disposable.swift in Sources */,
+				73ABF8211C40C682009179B9 /* StandardAction.swift in Sources */,
 				73D8435B1C243A8D00644EEC /* Store.swift in Sources */,
 				73D8433D1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
 				73D843421C243A8D00644EEC /* BindActionCreators.swift in Sources */,
 				73D383EC1C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
+				73ABF81C1C40C662009179B9 /* SimpleStandardAction.swift in Sources */,
 				73D843471C243A8D00644EEC /* Compose.swift in Sources */,
+				73ABF8261C40C69A009179B9 /* DefaultAction.swift in Sources */,
 				73061FAE1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843381C243A8D00644EEC /* Action.swift in Sources */,
 			);
@@ -758,11 +785,14 @@
 			files = (
 				73D843361C243A8D00644EEC /* Action.swift in Sources */,
 				73D8434A1C243A8D00644EEC /* CreateStore.swift in Sources */,
+				73ABF81E1C40C682009179B9 /* StandardAction.swift in Sources */,
 				73D843591C243A8D00644EEC /* Store.swift in Sources */,
 				73D843401C243A8D00644EEC /* BindActionCreators.swift in Sources */,
 				73D8434F1C243A8D00644EEC /* Disposable.swift in Sources */,
 				73D383E91C4098AA00A2F063 /* FluxStandardAction.swift in Sources */,
+				73ABF8191C40C662009179B9 /* SimpleStandardAction.swift in Sources */,
 				73D8433B1C243A8D00644EEC /* ApplyMiddleware.swift in Sources */,
+				73ABF8231C40C69A009179B9 /* DefaultAction.swift in Sources */,
 				73061FAB1C2BB644005FA55E /* MiddlewareApi.swift in Sources */,
 				73D843451C243A8D00644EEC /* Compose.swift in Sources */,
 			);

--- a/ReduxKit/Action.swift
+++ b/ReduxKit/Action.swift
@@ -9,59 +9,10 @@
 /**
  Basic action structure
  */
-public protocol Action {
-
-    var type: String { get }
-
-    var payload: Any? { get }
-
-    var meta: Any? { get }
-
-    var error: Bool { get }
-}
+public protocol Action {}
 
 public extension Action {
 
     /// Computed property that automatically fetches the actionType from the current action
     public var type: String { return "\(self.dynamicType.self)" }
-}
-
-/**
- Optional protocol used for when actions have to be created generically
-
- It requires a initializer to be present
- */
-public protocol StandardAction: SimpleStandardAction {
-
-    init(payload: PayloadType?, meta: Any?, error: Bool)
-}
-
-/**
- This is the StandardAction which is the recommended protocol to use when implementing actions.
-
- It is generic and expects a rawPayload of a generic type.
- */
-public protocol SimpleStandardAction: Action {
-
-    typealias PayloadType
-
-    var rawPayload: PayloadType { get }
-}
-
-public extension SimpleStandardAction {
-
-    /// Default implementation for payload
-    public var payload: Any? { return rawPayload }
-}
-
-
-public struct DefaultAction: SimpleStandardAction {
-
-    public let meta: Any? = nil
-
-    public let error: Bool = false
-
-    public let rawPayload: String = "$$ReduxKit-DefaultAction"
-
-    public init() {}
 }

--- a/ReduxKit/Action.swift
+++ b/ReduxKit/Action.swift
@@ -6,8 +6,16 @@
 //  Copyright © 2015 Kare Media. All rights reserved.
 //
 
+// MARK: Action protocol
+
 /**
- Basic action structure
+ Base action type all actions must conform to.
+
+ The Action protocol is intentionally minimal to allow Action types to best fit their situation.
+
+ If there are common properties needed on all Action types in you app, the Action protocol can be
+ extended and each action can inherit from the new protocol instead. See FluxStandardAction for a
+ good example of this in practice.
  */
 public protocol Action {}
 

--- a/ReduxKit/DefaultAction.swift
+++ b/ReduxKit/DefaultAction.swift
@@ -1,0 +1,9 @@
+//
+//  DefaultAction.swift
+//  ReduxKit
+//
+//  Created by Karl Bowden on 9/01/2016.
+//  Copyright © 2016 Kare Media. All rights reserved.
+//
+
+public struct DefaultAction: Action {}

--- a/ReduxKit/DefaultAction.swift
+++ b/ReduxKit/DefaultAction.swift
@@ -6,4 +6,6 @@
 //  Copyright © 2016 Kare Media. All rights reserved.
 //
 
-public struct DefaultAction: Action {}
+public struct DefaultAction: Action {
+    public init() {}
+}

--- a/ReduxKit/FluxStandardAction.swift
+++ b/ReduxKit/FluxStandardAction.swift
@@ -1,0 +1,68 @@
+//
+//  FluxStandardAction.swift
+//  ReduxKit
+//
+//  Created by Karl Bowden on 9/01/2016.
+//  Copyright © 2016 Kare Media. All rights reserved.
+//
+
+
+/**
+Basic action structure
+*/
+public protocol FluxStandardAction: Action {
+
+    var type: String { get }
+
+    var payload: Any? { get }
+
+    var meta: Any? { get }
+
+    var error: Bool { get }
+}
+
+//public extension Action {
+//
+//    /// Computed property that automatically fetches the actionType from the current action
+//    public var type: String { return "\(self.dynamicType.self)" }
+//}
+
+/**
+ Optional protocol used for when actions have to be created generically
+
+ It requires a initializer to be present
+ */
+public protocol StandardAction: SimpleStandardAction {
+
+    init(payload: PayloadType?, meta: Any?, error: Bool)
+}
+
+/**
+ This is the StandardAction which is the recommended protocol to use when implementing actions.
+
+ It is generic and expects a rawPayload of a generic type.
+ */
+public protocol SimpleStandardAction: FluxStandardAction {
+
+    typealias PayloadType
+
+    var rawPayload: PayloadType { get }
+}
+
+public extension SimpleStandardAction {
+
+    /// Default implementation for payload
+    public var payload: Any? { return rawPayload }
+}
+
+
+public struct DefaultAction: SimpleStandardAction {
+
+    public let meta: Any? = nil
+
+    public let error: Bool = false
+
+    public let rawPayload: String = "$$ReduxKit-DefaultAction"
+
+    public init() {}
+}

--- a/ReduxKit/FluxStandardAction.swift
+++ b/ReduxKit/FluxStandardAction.swift
@@ -8,8 +8,8 @@
 
 
 /**
-Basic action structure
-*/
+ Basic action structure
+ */
 public protocol FluxStandardAction: Action {
 
     var type: String { get }
@@ -19,50 +19,4 @@ public protocol FluxStandardAction: Action {
     var meta: Any? { get }
 
     var error: Bool { get }
-}
-
-//public extension Action {
-//
-//    /// Computed property that automatically fetches the actionType from the current action
-//    public var type: String { return "\(self.dynamicType.self)" }
-//}
-
-/**
- Optional protocol used for when actions have to be created generically
-
- It requires a initializer to be present
- */
-public protocol StandardAction: SimpleStandardAction {
-
-    init(payload: PayloadType?, meta: Any?, error: Bool)
-}
-
-/**
- This is the StandardAction which is the recommended protocol to use when implementing actions.
-
- It is generic and expects a rawPayload of a generic type.
- */
-public protocol SimpleStandardAction: FluxStandardAction {
-
-    typealias PayloadType
-
-    var rawPayload: PayloadType { get }
-}
-
-public extension SimpleStandardAction {
-
-    /// Default implementation for payload
-    public var payload: Any? { return rawPayload }
-}
-
-
-public struct DefaultAction: SimpleStandardAction {
-
-    public let meta: Any? = nil
-
-    public let error: Bool = false
-
-    public let rawPayload: String = "$$ReduxKit-DefaultAction"
-
-    public init() {}
 }

--- a/ReduxKit/SimpleStandardAction.swift
+++ b/ReduxKit/SimpleStandardAction.swift
@@ -7,9 +7,14 @@
 //
 
 /**
- This is the StandardAction which is the recommended protocol to use when implementing actions.
+ The SimpleStandardAction contains a strongly typed rawPayload property. It is generic and expects
+ a rawPayload of a generic type.
 
- It is generic and expects a rawPayload of a generic type.
+ The protocol automatically assigns the rawPayload to the Actions payload property. This removes
+ the necessity of type casting whenever working with actions in a reducer.
+
+ There's also the StandardAction protocol, that requires the struct to have an initializer. This is
+ required if the bindActionCreators helper is to be used.
  */
 public protocol SimpleStandardAction: FluxStandardAction {
 

--- a/ReduxKit/SimpleStandardAction.swift
+++ b/ReduxKit/SimpleStandardAction.swift
@@ -1,0 +1,25 @@
+//
+//  SimpleStandardAction.swift
+//  ReduxKit
+//
+//  Created by Karl Bowden on 9/01/2016.
+//  Copyright © 2016 Kare Media. All rights reserved.
+//
+
+/**
+ This is the StandardAction which is the recommended protocol to use when implementing actions.
+
+ It is generic and expects a rawPayload of a generic type.
+ */
+public protocol SimpleStandardAction: FluxStandardAction {
+
+    typealias PayloadType
+
+    var rawPayload: PayloadType { get }
+}
+
+public extension SimpleStandardAction {
+
+    /// Default implementation for payload
+    public var payload: Any? { return rawPayload }
+}

--- a/ReduxKit/StandardAction.swift
+++ b/ReduxKit/StandardAction.swift
@@ -1,0 +1,17 @@
+//
+//  StandardAction.swift
+//  ReduxKit
+//
+//  Created by Karl Bowden on 9/01/2016.
+//  Copyright © 2016 Kare Media. All rights reserved.
+//
+
+/**
+ Optional protocol used for when actions have to be created generically
+
+ It requires a initializer to be present
+ */
+public protocol StandardAction: SimpleStandardAction {
+
+    init(payload: PayloadType?, meta: Any?, error: Bool)
+}

--- a/ReduxKitPlayground.playground/Pages/Custom store creator.xcplaygroundpage/Contents.swift
+++ b/ReduxKitPlayground.playground/Pages/Custom store creator.xcplaygroundpage/Contents.swift
@@ -10,16 +10,17 @@ struct AppState {
     var count: Int!
 }
 
-struct CountAction: SimpleStandardAction {
-    let meta: Any? = nil
-    let error: Bool = false
-    let rawPayload: Int = 1
+struct CountAction: Action {
+    let payload: Int
+    init(_ payload: Int = 1) {
+        self.payload = payload
+    }
 }
 
 func reducer(state: AppState? = nil, action: Action) -> AppState {
     switch action {
     case let action as CountAction:
-        return AppState(count: (state?.count ?? 0) + action.rawPayload)
+        return AppState(count: (state?.count ?? 0) + action.payload)
     default:
         return state ?? AppState(count: 0)
     }
@@ -80,7 +81,7 @@ let countAndDump: () -> String = { _ in
 
 // ----------------------------------------------------------------------------
 
-dump() // -> AppState(count: 0)
+dump()         // -> AppState(count: 0)
 countAndDump() // -> AppState(count: 1)
 countAndDump() // -> AppState(count: 2)
 

--- a/ReduxKitPlayground.playground/Pages/Increment and decrement.xcplaygroundpage/Contents.swift
+++ b/ReduxKitPlayground.playground/Pages/Increment and decrement.xcplaygroundpage/Contents.swift
@@ -94,7 +94,7 @@ store.dispatch(IncrementAction())
 // AppState(count: 1)
 
 store.dispatch(IncrementAction())
-// AppState(count: 1)
+// AppState(count: 2)
 
 store.dispatch(DecrementAction())
 // AppState(count: 1)

--- a/ReduxKitPlayground.playground/Pages/Minimal example.xcplaygroundpage/Contents.swift
+++ b/ReduxKitPlayground.playground/Pages/Minimal example.xcplaygroundpage/Contents.swift
@@ -7,18 +7,36 @@ struct AppState {
     var count: Int!
 }
 
+enum CountEnumAction: Action {
+    case Increment
+    case Decrement
+    case Set(Int)
+}
+
 struct CountAction: SimpleStandardAction {
     let meta: Any? = nil
     let error: Bool = false
     let rawPayload: Int = 1
 }
 
-func reducer(state: AppState? = nil, action: Action) -> AppState {
+func reducer(previousState: AppState? = nil, action: Action) -> AppState {
+    let state = previousState ?? AppState(count: 0)
+
     switch action {
     case let action as CountAction:
-        return AppState(count: (state?.count ?? 0) + action.rawPayload)
+        return AppState(count: state.count + action.rawPayload)
+
+    case CountEnumAction.Increment:
+        return AppState(count: state.count + 1)
+
+    case CountEnumAction.Decrement:
+        return AppState(count: state.count - 1)
+
+    case CountEnumAction.Set(let value):
+        return AppState(count: value)
+
     default:
-        return state ?? AppState(count: 0)
+        return state
     }
 }
 
@@ -31,5 +49,13 @@ store.dispatch(CountAction())
 print(store.state) // -> AppState(count: 1)
 
 
-store.dispatch(CountAction())
+store.dispatch(CountEnumAction.Increment)
 print(store.state) // -> AppState(count: 2)
+
+
+store.dispatch(CountEnumAction.Decrement)
+print(store.state) // -> AppState(count: 1)
+
+
+store.dispatch(CountEnumAction.Set(99))
+print(store.state) // -> AppState(count: 99)

--- a/ReduxKitTests/ActionSpec.swift
+++ b/ReduxKitTests/ActionSpec.swift
@@ -85,7 +85,7 @@ class ActionSpec: QuickSpec {
                 let actualType = MyAction().type
 
                 // Assert
-                expect(actualType is String).to(beTruthy())
+                expect((actualType as Any) is String).to(beTruthy())
             }
 
             it("should contains the type name") {

--- a/ReduxKitTests/ActionSpec.swift
+++ b/ReduxKitTests/ActionSpec.swift
@@ -80,7 +80,15 @@ class ActionSpec: QuickSpec {
             struct MyAction: Action {}
             let expectedTypeContent = "MyAction"
 
-            it("should be a string that contains the type name") {
+            it("should be a string") {
+                // Act
+                let actualType = MyAction().type
+
+                // Assert
+                expect(actualType is String).to(beTruthy())
+            }
+
+            it("should contains the type name") {
                 // Act
                 let actualType = MyAction().type
 

--- a/ReduxKitTests/ActionSpec.swift
+++ b/ReduxKitTests/ActionSpec.swift
@@ -12,27 +12,89 @@ import Nimble
 
 class ActionSpec: QuickSpec {
 
+    // swiftlint:disable function_body_length
+    // swiftlint:disable nesting
     override func spec() {
 
-        describe("ActionSpec") {
+        let expectedString = "expectedString"
 
-            it("should dispatch actions that conform to Action") {
-                // Arrange
-                let expectedString = "expectedString"
-                struct TestState {
-                    let value: String
-                }
-                func testReducer(state: TestState? = nil, action: Action) -> TestState {
-                    return state ?? TestState(value: expectedString)
-                }
-                let store = createStore(testReducer, state: nil)
+        struct TestState {
+            let value: String
+        }
 
+        func testReducer(state: TestState? = nil, action: Action) -> TestState {
+            return state ?? TestState(value: expectedString)
+        }
+
+        var store: Store<TestState>!
+
+        beforeEach {
+            store = createStore(testReducer, state: nil)
+        }
+
+        describe("Action protocol conformance") {
+
+            context("enum action") {
+                it("should dispatch enums that conform to Action") {
+                    // Arrange
+                    enum MyAction: Action { case Default }
+
+                    // Act
+                    store.dispatch(MyAction.Default)
+
+                    // Assert
+                    expect(store.getState().value).to(equal(expectedString))
+                }
+            }
+
+            context("struct action") {
+                it("should dispatch structs that conform to Action") {
+                    // Arrange
+                    struct MyAction: Action {}
+
+                    // Act
+                    store.dispatch(MyAction())
+
+                    // Assert
+                    expect(store.getState().value).to(equal(expectedString))
+                }
+            }
+
+            context("class action") {
+                it("should dispatch classes that conform to Action") {
+                    // Arrange
+                    class MyAction: Action {}
+
+                    // Act
+                    store.dispatch(MyAction())
+
+                    // Assert
+                    expect(store.getState().value).to(equal(expectedString))
+                }
+            }
+        }
+
+        describe("Action.type") {
+
+            // Arrange
+            struct MyAction: Action {}
+            let expectedTypeContent = "MyAction"
+
+            it("should be a string that contains the type name") {
                 // Act
-                class MyAction: Action {}
-                store.dispatch(MyAction())
+                let actualType = MyAction().type
 
                 // Assert
-                expect(store.getState().value).to(equal(expectedString))
+                expect(actualType).to(contain(expectedTypeContent))
+            }
+
+            it("should stay the same across instances") {
+                // Act
+                let firstType = MyAction().type
+                let secondType = MyAction().type
+
+                // Assert
+                expect(firstType).to(equal(secondType))
             }
         }
     }

--- a/ReduxKitTests/ActionSpec.swift
+++ b/ReduxKitTests/ActionSpec.swift
@@ -1,5 +1,5 @@
 //
-//  StoreSpec.swift
+//  ActionSpec.swift
 //  ReduxKit
 //
 //  Created by Karl Bowden on 9/01/2016.
@@ -10,11 +10,11 @@ import Quick
 import Nimble
 @testable import ReduxKit
 
-class StoreSpec: QuickSpec {
+class ActionSpec: QuickSpec {
 
     override func spec() {
 
-        describe("StoreSpec") {
+        describe("ActionSpec") {
 
             it("should dispatch actions that conform to Action") {
                 // Arrange

--- a/ReduxKitTests/ActionTypeSpec.swift
+++ b/ReduxKitTests/ActionTypeSpec.swift
@@ -16,12 +16,13 @@ class ActionTypeSpec: QuickSpec {
 
         describe("ActionTypeSpec") {
 
+            // swiftlint:disable line_length
             it("should succesfully retrieve payload from actionType") {
 
                 // Arrange
-                let incrementAction = IncrementAction() as Action
-                let pushAction = PushAction(payload: nil) as Action
-                let updateTextFieldAction = UpdateTextFieldAction(payload: nil) as Action
+                let incrementAction = IncrementAction() as FluxStandardAction
+                let pushAction = PushAction(payload: nil) as FluxStandardAction
+                let updateTextFieldAction = UpdateTextFieldAction(payload: nil) as FluxStandardAction
 
                 // Act
                 let incrementPayload = incrementAction.payload

--- a/ReduxKitTests/BindActionCreatorsSpec.swift
+++ b/ReduxKitTests/BindActionCreatorsSpec.swift
@@ -17,20 +17,20 @@ class BindActionCreatorsSpec: QuickSpec {
     override func spec() {
 
         describe("BindActionCreators") {
+
+            // Arrange
+            var state: AppState!
             var defaultState: AppState!
             var store: Store<AppState>!
+            let textMessage = "test"
 
             beforeEach {
                 store = createStore(applicationReducer, state: nil)
                 defaultState = store.state
+                store.subscribe { state = $0 }
             }
 
             it("should succesfully create an action method that calls the store's dispatch with nil value") {
-
-                // Arrange
-                var state: AppState!
-                store.subscribe { state = $0 }
-
                 // Act
                 let increment = bindActionCreators(IncrementAction.self, dispatch: store.dispatch)
 
@@ -42,12 +42,6 @@ class BindActionCreatorsSpec: QuickSpec {
             }
 
             it("should succesfully create an action method that calls the store's dispatch with an actual value") {
-                // Arrange
-                var state: AppState!
-                let textMessage = "test"
-
-                store.subscribe { state = $0 }
-
                 // Act
                 let push = bindActionCreators(PushAction.self, dispatch: store.dispatch)
 

--- a/ReduxKitTests/FluxStandardActionSpec.swift
+++ b/ReduxKitTests/FluxStandardActionSpec.swift
@@ -14,7 +14,7 @@ class FluxStandardActionSpec: QuickSpec {
 
     override func spec() {
 
-        describe("FluxStandardActionSpec") {
+        describe("FluxStandardAction") {
 
             // swiftlint:disable line_length
             it("should succesfully retrieve payload from FluxStandardAction types") {

--- a/ReduxKitTests/FluxStandardActionSpec.swift
+++ b/ReduxKitTests/FluxStandardActionSpec.swift
@@ -1,5 +1,5 @@
 //
-//  ActionTypeSpec.swift
+//  FluxStandardActionSpec.swift
 //  ReduxKit
 //
 //  Created by Aleksander Herforth Rendtslev on 06/11/15.
@@ -10,14 +10,14 @@ import Quick
 import Nimble
 @testable import ReduxKit
 
-class ActionTypeSpec: QuickSpec {
+class FluxStandardActionSpec: QuickSpec {
 
     override func spec() {
 
-        describe("ActionTypeSpec") {
+        describe("FluxStandardActionSpec") {
 
             // swiftlint:disable line_length
-            it("should succesfully retrieve payload from actionType") {
+            it("should succesfully retrieve payload from FluxStandardAction types") {
 
                 // Arrange
                 let incrementAction = IncrementAction() as FluxStandardAction

--- a/ReduxKitTests/StoreSpec.swift
+++ b/ReduxKitTests/StoreSpec.swift
@@ -1,0 +1,39 @@
+//
+//  StoreSpec.swift
+//  ReduxKit
+//
+//  Created by Karl Bowden on 9/01/2016.
+//  Copyright © 2016 Kare Media. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import ReduxKit
+
+class StoreSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("StoreSpec") {
+
+            it("should dispatch actions that conform to Action") {
+                // Arrange
+                let expectedString = "expectedString"
+                struct TestState {
+                    let value: String
+                }
+                func testReducer(state: TestState? = nil, action: Action) -> TestState {
+                    return state ?? TestState(value: expectedString)
+                }
+                let store = createStore(testReducer, state: nil)
+
+                // Act
+                class MyAction: Action {}
+                store.dispatch(MyAction())
+
+                // Assert
+                expect(store.getState().value).to(equal(expectedString))
+            }
+        }
+    }
+}

--- a/docs/Bindings.md
+++ b/docs/Bindings.md
@@ -1,6 +1,6 @@
 ## Bindings
 
-The ReduxKit Store is, at it's heart, a subscribable stream of states. You are likely already familiar with the concept from reactive frameworks. The two are so similar in fact that you will more than likely want to use ReduxKit with you favourite reactive framework.
+The ReduxKit Store is, at it's heart, a stream of states over time that can be subscribed to. You are likely already familiar with the concept from reactive frameworks. The two are so similar in fact that you will more than likely want to use ReduxKit with you favourite reactive framework.
 
 It is very easy to create a createStore function that wraps existing reactive frameworks. ReduxKit already has bindings available for:
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -2,7 +2,7 @@
 
 ### How can you help?
 
-Pull requests are welcome on the develop branch.
+Pull requests are welcome on the master branch.
 
 I am hoping to get a solid influx of middleware up and running for ReduxKit so we can change the way we do iOS development in the future. I am therefore welcoming pull requests, feature requests and suggestions. I want this library to be the best it can be and I can only do that with the help of the rest of you.
 

--- a/docs/Flux Standard Actions.md
+++ b/docs/Flux Standard Actions.md
@@ -1,5 +1,0 @@
-# Flux Standard Actions
-
-ReduxKit `Action`s are implemented as [Flux Standard Actions](https://github.com/acdlite/flux-standard-action). Defining an Action protocol with ReduxKit makes interacting with the Store and State easier. FSA allows for a lot of flexibility while still maintaining a standard pattern.
-
-See [Actions](Actions.html) for further documentation.

--- a/docs/The Gist.md
+++ b/docs/The Gist.md
@@ -6,34 +6,34 @@ A more advanced Swift example of the original [gist](https://github.com/rackt/re
 import ReduxKit
 
 /**
- This is a simple standard action. The only requirement is that an action complies to
- the Action protocol. The SimpleStandardAction contains a strongly typed rawPayload
- property. The protocol automatically assigns the rawPayload to the Actions payload
- property. This removes the necessity of type casting whenever working with actions in
- a reducer.
+ This is an extremely simple and flexible action. The only requirement for actions is that they
+ conform to the Action protocol.
 
- There's also the StandardAction protocol, that requires the struct to have an
- initializer. This is required if the bindActionCreators helper is to be used.
+ The Action protocol can be inherited from for app specific Action requirements. For a good example
+ of this, see FluxStandardAction and the implementing types in the source.
+
+ Action can be implemented as an enum, struct or class.
  */
-struct IncrementAction: SimpleStandardAction {
-    let meta: Any? = nil
-    let error: Bool = false
-    let rawPayload: Int = 1
+struct IncrementAction: Action {
+    let payload: Int
+    init(payload: Int = 1) {
+        self.payload = payload
+    }
 }
 
-struct DecrementAction: SimpleStandardAction {
-    let meta: Any? = nil
-    let error: Bool = false
-    let rawPayload: Int = 1
+struct DecrementAction: Action {
+    let payload: Int
+    init(payload: Int = 1) {
+        self.payload = payload
+    }
 }
 
 /**
- This is a simple reducer. It is a pure function that follows the syntax
- (state, action) -> state.
+ This is a simple reducer. It is a pure function that follows the syntax (State, Action) -> State.
  It describes how an action transforms the previous state into the next state.
 
- Instead of using the actions.type property - as is done in the regular Redux framework
- we use the power of Swifts static typing to deduce the action.
+ Instead of using the Action.type property - as is done in the regular Redux framework we use the
+ power of Swifts static typing to deduce the action.
  */
 func counterReducer(previousState: Int?, action: Action) -> Int {
     // Declare the reducers default value
@@ -42,9 +42,9 @@ func counterReducer(previousState: Int?, action: Action) -> Int {
 
     switch action {
         case let action as IncrementAction:
-            return state + action.rawPayload
+            return state + action.payload
         case let action as DecrementAction:
-            return state - action.rawPayload
+            return state - action.payload
         default:
             return state
     }
@@ -52,32 +52,31 @@ func counterReducer(previousState: Int?, action: Action) -> Int {
 
 /**
  The applications state. This should contain the state of the whole application.
- When building larger applications, you can optionally assign complex structs to
- properties on the AppState and handle them in the part of the application that
- uses them.
+ When building larger applications, you can optionally assign complex structs to properties on the
+ AppState and handle them in the part of the application that uses them.
  */
 struct AppState {
-  var count: Int!
+    var count: Int!
 }
 
 /**
- Create the applications reducer. While we could create a combineReducer function
- we've currently chosen to allow reducers to be statically typed and accept
- static states - instead of Any - which currently forces us to define the
- application reducer as such. This could possibly be simplified with reflection.
+ Create the applications reducer. While we could create a combineReducer function we've currently
+ chosen to allow reducers to be statically typed and accept static states - instead of Any - which
+ currently forces us to define the application reducer as such. This could possibly be simplified
+ with reflection.
  */
 let applicationReducer = {(state: AppState? = nil, action: Action) -> AppState in
 
-  return AppState(
-    count: counterReducer(state?.count, action: action),
+    return AppState(
+        count: counterReducer(state?.count, action: action),
     )
 }
 
 // Create application store. The second parameter is an optional default state.
 let store = createStore(applicationReducer, nil)
 
-let disposable = store.subscribe{ state in
-  print(state)
+let disposable = store.subscribe { state in
+    print(state)
 }
 
 

--- a/docs/api/Actions.md
+++ b/docs/api/Actions.md
@@ -1,0 +1,43 @@
+## Plain Actions
+
+ReduxKit only defines a minimal protocol that `Action` types must conform to. Action types can be enums, structs or classes. Examples:
+
+```swift
+// A simple enum with three actions
+enum CountAction: Action {
+	case Increment
+	case Decrement
+	case Set(payload: Int)
+}
+
+// The IncrementAction as a struct:
+struct IncrementAction: Action {
+	let payload: Int
+}
+
+// Or even a class
+class IncrementActionClass: Action {
+	let payload: Int
+	init(payload: Int) {
+		self.payload = payload
+	}
+}
+```
+
+## Flux Standard Actions
+
+[Flux Standard Actions](https://github.com/acdlite/flux-standard-action) are also implemented for applications that require consistent Actions. Flux Standard Actions allows for a lot of flexibility while still maintaining a standard pattern. Example:
+
+```swift
+struct IncrementAction: StandardAction {
+    let meta: Any?
+    let error: Bool
+    let rawPayload: Int
+
+    init(payload: Int? = nil, meta: Any? = nil, error: Bool = false) {
+        self.rawPayload = payload ?? 1
+        self.meta = meta
+        self.error = error
+    }
+}
+```

--- a/docs/api/Documentation.md
+++ b/docs/api/Documentation.md
@@ -25,7 +25,6 @@ It is currently implemented in a few swift apps and is frequently updated. Addit
 - [Types and generic State](types-and-generic-state.html)
 - [Bindings](bindings.html)
 - [Redux Compatibility](redux-compatibility.html)
-- [Flux Standard Actions](flux-standard-actions.html)
 - [Contributing](contributing.html)
 - [Progress](progress.html)
 - [License](license.html)

--- a/docs/api/Middleware.md
+++ b/docs/api/Middleware.md
@@ -1,3 +1,3 @@
-## Available Middleware
+## Middleware projects
 
 - [ReduxKitRouter](https://github.com/ReduxKit/ReduxKitRouter) - Routing middleware

--- a/docs/api/Stores.md
+++ b/docs/api/Stores.md
@@ -2,4 +2,4 @@ ReduxKit stores are constructed with a `createStore` function that returns the `
 
 The store creation functions can be easily replaced if needed or wrapped with a `StoreEnhancer`.
 
-Using a completely generic store creator means you are able to construct state out of any object in swift.
+Using a completely generic store creator allows construction out of any object in swift.


### PR DESCRIPTION
Fixes #29
- Rename existing Action to FluxStandardAction
- Create new empty Action protocol
- Test changes
- Cleanup filenames and tests
- Update documentation
- Update playgrounds
